### PR TITLE
add fake alert to test code rabbit

### DIFF
--- a/pkg/monitoring/hyperconverged/rules/alerts/operator_alerts.go
+++ b/pkg/monitoring/hyperconverged/rules/alerts/operator_alerts.go
@@ -22,6 +22,19 @@ const (
 func operatorAlerts() []promv1.Rule {
 	return []promv1.Rule{
 		{
+			Alert: "VMMemoryOvercommitTooHigh",
+			Expr:  intstr.FromString("kubevirt_hco_memory_overcommit_percentage > 150"),
+			For:   ptr.To(promv1.Duration("10m")),
+			Annotations: map[string]string{
+				"description": "The cluster-wide VM memory overcommit percentage exceeds 150%, which may lead to memory pressure and VM evictions.",
+				"summary":     "HCO memory overcommit percentage is dangerously high ({{ $value }}%).",
+			},
+			Labels: map[string]string{
+				severityAlertLabelKey:     "warning",
+				healthImpactAlertLabelKey: "warning",
+			},
+		},
+		{
 			Alert: outOfBandUpdateAlert,
 			Expr:  intstr.FromString("sum by(component_name) ((round(increase(kubevirt_hco_out_of_band_modifications_total[10m]))>0 and kubevirt_hco_out_of_band_modifications_total offset 10m) or (kubevirt_hco_out_of_band_modifications_total != 0 unless kubevirt_hco_out_of_band_modifications_total offset 10m))"),
 			Annotations: map[string]string{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Reviewer Checklist**
<!-- Check [Expectations from a PR](/CONTRIBUTING.md#expectations-from-a-pr) for the details -->

> Reviewers are supposed to review the PR for every aspect below one by one. To check an item means the PR is either "OK" or "Not Applicable" in terms of that item. All items are supposed to be checked before merging a PR. 

- [ ] PR Message
- [ ] Commit Messages
- [ ] How to test
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] User Documentation
- [ ] Developer Documentation
- [ ] Upgrade Scenario
- [ ] Uninstallation Scenario
- [ ] Backward Compatibility
- [ ] Troubleshooting Friendly

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket

```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new memory overcommit monitoring alert that triggers when memory overcommit exceeds 150% for sustained periods, helping operators monitor system health.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/avlitman/hyperconverged-cluster-operator/pull/3)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->